### PR TITLE
pyerfa 2.0.1.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyerfa" %}
-{% set version = "2.0.1.4" %}
+{% set version = "2.0.1.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: acb8a6713232ea35c04bc6e40ac4e461dfcc817d395ef2a3c8051c1a33249dd3
+  sha256: 17d6b24fe4846c65d5e7d8c362dcb08199dc63b30a236aedd73875cc83e1f6c0
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - pip
     - wheel
-    - setuptools
+    - setuptools >=61.2
     - setuptools_scm >=6.2
     - jinja2 >=2.10.3
     # Build currently fails on python 3.9 & 3.10 without this pinning included.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,11 +26,11 @@ requirements:
     - jinja2 >=2.10.3
     # Build currently fails on python 3.9 & 3.10 without this pinning included.
     # Also upstream documentation is not accurate when building with numpy 1.
-    - numpy 1.22 # [py<311]
-    - numpy {{ numpy }} # [py>=311]
+    - numpy 2.0 # [py<313]
+    - numpy 2.1 # [py>=313]
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy >=1.19.3
 
 test:
   requires:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6875](https://anaconda.atlassian.net/browse/PKG-6875)
- [Upstream repository](https://github.com/liberfa/pyerfa/tree/v2.0.1.5)
- [Upstream changelog/diff](https://github.com/liberfa/pyerfa/blob/v2.0.1.5/CHANGES.rst)
- Relevant dependency PRs:
  - dependency for `astropy`

### Explanation of changes:

- Update version and sha
- Build for python 3.13
- Update dependencies


[PKG-6875]: https://anaconda.atlassian.net/browse/PKG-6875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ